### PR TITLE
chore: post-ship polish — SPA 404 fallback, favicon, SEO tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules
 coverage
 .gstack/
 .superpowers/
+.vite/

--- a/index.html
+++ b/index.html
@@ -2,21 +2,21 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Instrument+Serif&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Praneeth Papishetty — Staff Engineer at Slack. Database reliability, distributed systems, and platform engineering." />
+    <meta name="description" content="Praneeth Papishetty — Builder, Datastores at Slack. I build tools for the people who keep production alive. Previously DIM (Database Infra Manager) at Warner Bros. Discovery, with seven years of database infrastructure across HBO Max and the WBD streaming stack." />
     <meta name="author" content="Praneeth Papishetty" />
-    <meta property="og:title" content="Praneeth Papishetty" />
-    <meta property="og:description" content="Staff Engineer at Slack. Click my past employers to see my work in their UI style." />
+    <meta property="og:title" content="Praneeth Papishetty — Builder · Datastores · Slack" />
+    <meta property="og:description" content="I build tools for the people who keep production alive. Currently on Slack's Datastores Foundation squad. Built DIM at Warner Bros. Discovery: 3 weeks → 12 hours across 1,200+ Aurora clusters." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://praneethpapishetty.com" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Praneeth Papishetty" />
-    <meta name="twitter:description" content="Staff Engineer at Slack. Portfolio with company-themed UI transformations." />
-    <title>Praneeth Papishetty — Staff Engineer</title>
+    <meta name="twitter:title" content="Praneeth Papishetty — Builder, Datastores at Slack" />
+    <meta name="twitter:description" content="I build tools for the people who keep production alive. Builder · Datastores · Slack." />
+    <title>Praneeth Papishetty — Builder, Datastores at Slack</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Praneeth Papishetty</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script>
+  // SPA fallback: any unmatched URL gets redirected to the hash-routed equivalent
+  // so HashRouter can resolve it. e.g. /blog -> /#/blog
+  (function () {
+    var path = window.location.pathname.replace(/\/$/, '');
+    var search = window.location.search;
+    if (path && path !== '/index.html') {
+      window.location.replace('/#' + path + search);
+    } else {
+      window.location.replace('/');
+    }
+  })();
+</script>
+</head>
+<body>
+<p>Redirecting to <a href="/">praneethpapishetty.com</a>...</p>
+</body>
+</html>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <rect width="40" height="40" rx="9" fill="#0a0a0a"/>
+  <path d="M13 28 V12 H22 a6 6 0 0 1 0 12 H17" stroke="#f4f2ed" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="27" cy="28" r="1.6" fill="#c96a3a"/>
+</svg>


### PR DESCRIPTION
## Summary

Three small fixes after PR #5 went live, plus a `.gitignore` add.

### `public/404.html` — SPA fallback

GitHub Pages serves a generic *"site does not contain the requested file"* page for any path that isn't a real file in the deployed artifact. That meant:
- Anyone hitting a stale link from the old HTML5 UP template (`/elements.html`, `/work.html`) saw a 404.
- Anyone typing `/blog` directly (instead of `/#/blog`) saw a 404.
- Browser caches that pointed at old asset paths could resolve to a 404 too.

`404.html` now captures all unmatched URLs and redirects them to the hash-routed equivalent (`/blog` → `/#/blog`, `/anything` → `/#/anything`). HashRouter then resolves the route. Unknown routes fall through to `*` which renders the unified portfolio.

### `public/favicon.svg` — real favicon

`index.html` referenced `/favicon.ico` but no file existed, producing a console 404 on every page load. Added an SVG favicon using the same brand mark as the header (black rounded square, white "P", orange dot accent). One file, scales perfectly.

Updated `index.html` to reference `/favicon.svg` with `type="image/svg+xml"`.

### Refresh SEO meta tags

The `og:description` and `twitter:description` still described the *previous* themed-shells concept ("Click my past employers to see my work in their UI style", "company-themed UI transformations"). Anyone sharing the URL on Slack/X/LinkedIn would have surfaced stale messaging. Updated to reflect the unified portfolio and the builder identity from the hero.

Updated `<title>` and `og:title` to "Praneeth Papishetty — Builder, Datastores at Slack".

### `.gitignore`: add `.vite/`

Vite's local dependency pre-bundle cache (`.vite/deps/`) is generated by `npm run dev` and shouldn't be tracked. First commit attempt accidentally pulled in ~30k lines of generated JS — caught and reverted before push.

## Test plan
- [x] `npm run build` clean (40 modules, 1.87s)
- [x] `npx vitest run` — 7/7 passing
- [x] `dist/404.html`, `dist/favicon.svg`, `dist/index.html` all present in build artifact
- [ ] Post-merge: visit `praneethpapishetty.com/elements.html` → should redirect to home (instead of GH Pages 404)
- [ ] Post-merge: tab favicon should render the brand mark, not the missing-icon placeholder
- [ ] Post-merge: paste `praneethpapishetty.com` into Slack/X — preview should show new title + description