### PR TITLE
fix: drop false claim from hero bio that DIM delivered 1,200 clusters

### DIFF
--- a/src/data/personal.ts
+++ b/src/data/personal.ts
@@ -5,7 +5,7 @@ export const personal: PersonalData = {
   title: 'Builder · Datastores · Slack',
   location: 'Kirkland, WA',
   bio: [
-    "I build tools for the people who keep production alive. At Warner Bros. Discovery, that meant DIM — a platform that turned a three-week database provisioning ticket into a twelve-hour self-serve flow across 1,200+ Aurora clusters. Now I'm on Slack's Datastores Foundation team, applying the same playbook to Vitess and MySQL at a much louder scale.",
+    "I build tools for the people who keep production alive. At Warner Bros. Discovery, that meant DIM — a platform that turned a three-week database provisioning ticket into a twelve-hour self-serve flow. Now I'm on Slack's Datastores Foundation team, applying the same playbook to Vitess and MySQL at a much louder scale.",
     'Took the long way in — pharmacy, then chemistry, then databases finally stuck. The work I keep coming back to is the same: spot the friction, ship the tool that eliminates it, move on.',
   ],
   email: 'me@praneethpapishetty.com',


### PR DESCRIPTION
## Summary

The hero bio still had the same misleading framing we already fixed in the WBD era section — slipped through into `personal.ts` because we corrected the era content first, then forgot to revisit the hero.

**Before:**

> I build tools for the people who keep production alive. At Warner Bros. Discovery, that meant DIM — a platform that turned a three-week database provisioning ticket into a twelve-hour self-serve flow **across 1,200+ Aurora clusters**. Now I'm on Slack's Datastores Foundation team...

The bolded clause implied DIM delivered the 1,200-cluster fleet. Not true: that fleet was maintained by the DRE team for years before DIM existed. DIM is the platform serving the fleet, not the thing that produced it. DIM shipped Dec 2025 and has delivered ~40–50 clusters since.

**After:**

> I build tools for the people who keep production alive. At Warner Bros. Discovery, that meant DIM — a platform that turned a three-week database provisioning ticket into a twelve-hour self-serve flow. Now I'm on Slack's Datastores Foundation team...

The 1,200 number didn't disappear — it still lives where the framing is honest, in the WBD era tagline a few sections down:

> Seven years on the DRE team for HBO Max and WBD streaming — 1,200+ Aurora clusters, 300+ DynamoDB tables, 100+ ElastiCache. DIM was the platform we built to keep all of it deployable.

That phrasing correctly says DIM was built *for* the fleet, not that DIM produced it.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run` — 7/7 passing
- [x] Hero paragraph 1 reads cleanly without the dropped clause
- [x] WBD era section still surfaces the 1,200 number with truthful framing